### PR TITLE
Tiny fix error "SyntaxError: invalid escape sequence '\%'"

### DIFF
--- a/modeling/math_equivalence.py
+++ b/modeling/math_equivalence.py
@@ -101,7 +101,7 @@ def _strip_string(string):
 
     # remove percentage
     string = string.replace("\\%", "")
-    string = string.replace("\%", "")
+    string = string.replace("%", "")
 
     # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
     string = string.replace(" .", " 0.")


### PR DESCRIPTION
The original code gives syntax error:

```
E     File "math_equivalence.py", line 110
E       string = string.replace("\%", "")
E                               ^^^^
E   SyntaxError: invalid escape sequence '\%'
```

I guess it means "%" so made this tiny change. Please correct me if I am wrong!